### PR TITLE
Fix deadlock with large output

### DIFF
--- a/data/src/transform.py
+++ b/data/src/transform.py
@@ -35,6 +35,8 @@ def shell_exec(command):
     '''
     # Get absolute path of bash
     bash = os.popen('command -v bash').read().rstrip('\r\n')
+
+    # Execute
     cpt = subprocess.Popen(
         command,
         executable=bash,
@@ -42,11 +44,6 @@ def shell_exec(command):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
-
-    # Wait until process terminates (without using p.wait())
-    while cpt.poll() is None:
-        # Process hasn't exited yet, let's wait some more time
-        time.sleep(0.1)
 
     # Get stdout, stderr and return code
     stdout, stderr = cpt.communicate()


### PR DESCRIPTION
## Description

This fixes a deadlock in subprocess open when stdout/stderr becomes to big. Polling for the command to finish was done forever resulting in no output and timeouts.

The fix is to only use `communicate()` instead of `poll()` or `wait()`


## References

* https://stackoverflow.com/questions/2502833/store-output-of-subprocess-popen-call-in-a-string
* https://stackoverflow.com/questions/1180606/using-subprocess-popen-for-process-with-large-output?noredirect=1