### PR TITLE
Fix regular expression for Kubernetes v1.11.10

### DIFF
--- a/data/src/transform.py
+++ b/data/src/transform.py
@@ -225,7 +225,7 @@ def get_pod_metrics_from_cli():
     ret, out, err = shell_exec(command)
 
     # 1:NS | 2:Name | 3:Ready | 4:Status | 5:Restarts | 6:Age | 7:IP | 8:Node
-    reg = re.compile(r"^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)$")
+    reg = re.compile(r"^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)$")
 
     for line in out.splitlines():
         line = line.decode("utf-8")

--- a/data/src/transform.py
+++ b/data/src/transform.py
@@ -224,7 +224,7 @@ def get_pod_metrics_from_cli():
     command = 'kubectl get pods -o wide --no-headers --all-namespaces'
     ret, out, err = shell_exec(command)
 
-    # 1:NS | 2:Name | 3:Ready | 4:Status | 5:Restarts | 6:Age | 7:IP | 8:Node
+    # 1:NS | 2:Name | 3:Ready | 4:Status | 5:Restarts | 6:Age | 7:IP | 8:Node | 9: NOMINATED NODE
     reg = re.compile(r"^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)$")
 
     for line in out.splitlines():


### PR DESCRIPTION
In Kubernetes `v1.11.10` the command `kubectl get pods -o wide --no-headers --all-namespaces` returns data in the following format:

```bash
samba              samba-774f847d9b-2qrth                                             1/1   Running            0     1h    10.6.181.3    ip-10-0-0-2.eu-central-1.compute.internal     <none>
```

Example with headers:

```bash
$ kubectl get pods -o wide --all-namespaces
NAMESPACE               NAME                                                                    READY   STATUS              RESTARTS   AGE   IP                NODE                                             NOMINATED NODE
samba              samba-774f847d9b-2qrth                                             1/1   Running            0     1h    10.6.181.3    ip-10-0-0-2.eu-central-1.compute.internal     <none>
```